### PR TITLE
Escort Framework Rework (AI-Written)

### DIFF
--- a/Database/Language/en.ini
+++ b/Database/Language/en.ini
@@ -208,6 +208,9 @@ SmokeNearAffirm=Tossed a smoke grenade. Target is "..tostring(briefingRoom.missi
 SmokeNearby=Already tossed a smoke. Target is "..tostring(briefingRoom.mission.objectiveFeatures[$OBJECTIVEINDEX$].targetDesignationSmokeMarkerInaccurateDistance).." meters "..dcsExtensions.degreesToCardinalDirection(briefingRoom.mission.objectiveFeatures[$OBJECTIVEINDEX$].targetDesignationSmokeMarkerInaccurateHeading).." of the smoke.
 LaunchAttack=Launch Attack
 LaunchAttackRequest=Ground Forces, I'm ready to support, Launch Attack
+FriendlyForcesList=Friendly Forces
+FriendlyForcesArea=Friendly Forces Area
+FriendlyForcesLabel=Friendly:
 
 [Objectives]
 CargoDelivered=Command, Cargo Delivered.
@@ -334,12 +337,12 @@ RandomSeedActiveWarning="Seed pinned: this template will produce the same missio
 ClearRandomSeed="Clear seed"
 
 [CampaignGenerator]
-ContextAndEnviroment=Context & Eviroment
+ContextAndEnviroment=Context & Environment
 BadWeatherChance=Bad weather chance
 NightMissionChance=Night mission chance
 MissionCount=Mission count (zero means random)
 MissionDifficultyVariation=Mission difficulty variation
-ObjectivesCount=Objecives Count
+ObjectivesCount=Objectives Count
 ObjectivesDistance=Objectives Distance
 ObjectiveVariationDistance=Objective Variation Distance
 AirbaseVariationDistance=Airbase Variation Distance
@@ -432,6 +435,7 @@ All=All
 AlliesOnly=Allies only
 KnownUnitsOnly=Known units only
 SelfOnly=Self only
+PlayerSettings=Player settings
 
 [ObjectiveOption]
 EmbeddedAirDefense=Embedded air defense
@@ -539,6 +543,7 @@ RecoverableErrorRetryUsageExhausted=Recoverable Error retries used: {0}/{1} (no 
 ExtremeDistanceRetryUsage=Extreme distance retries used: {0}/{1}.
 ExtremeDistanceRetryUsageExhausted=Extreme distance retries used: {0}/{1} (no retries left).
 ObjectiveStageRepeatedFailure=Objective stage repeated the same failure {0} times (cutoff {1}): {2}
+StageRepeatedFailureCutoff=Stage {0} repeatedly failed ({1}/{2} times) with error: {3}. Falling back to previous stage to retry.
 ExcessDistance=Distance to objectives exceeds 1.7x of requested distance. ({0}NM)
 CAPCannotBeSpawnedAirport=CAP flight could not be placed at airport: {0}
 FailedToFindCAPUnits=Failed to find units for {0} air defense unit group.

--- a/Database/Language/es.ini
+++ b/Database/Language/es.ini
@@ -431,7 +431,8 @@ Decade2020=2020s
 All=Todos
 AlliesOnly=Solo aliados
 KnownUnitsOnly=Solo unidades conocidas
-SelfOnly=Solo uno mismo
+SelfOnly=Solo propias
+PlayerSettings=Ajustes del jugador
 
 [ObjectiveOption]
 EmbeddedAirDefense=Defensa aérea integrada

--- a/Database/Language/ru.ini
+++ b/Database/Language/ru.ini
@@ -430,8 +430,9 @@ Decade2020=2020е
 [FogOfWar]
 All=Все
 AlliesOnly=Только союзники
-KnownUnitsOnly=Только известные юниты
-SelfOnly=Только для себя
+KnownUnitsOnly=Только обнаруженные объекты
+SelfOnly=Только свои
+PlayerSettings=Настройки игрока
 
 [ObjectiveOption]
 EmbeddedAirDefense=Встроенная противовоздушная оборона

--- a/Database/Language/tk.ini
+++ b/Database/Language/tk.ini
@@ -425,13 +425,15 @@ Decade1980=1980'ler
 Decade1990=1990'lar
 Decade2000=2000'ler
 Decade2010=2010'lar
+Decade2010=2010'ler
 Decade2020=2020'ler
 
 [FogOfWar]
 All=Tümü
 AlliesOnly=Yalnızca müttefikler
-KnownUnitsOnly=Yalnızca bilinen birimler
-SelfOnly=Yalnızca kendi kendine
+KnownUnitsOnly=Sadece bilinen birimler
+SelfOnly=Sadece kendi birimlerin
+PlayerSettings=Oyuncu ayarları
 
 [ObjectiveOption]
 EmbeddedAirDefense=Gömülü hava savunması

--- a/Database/Language/uk.ini
+++ b/Database/Language/uk.ini
@@ -430,8 +430,9 @@ Decade2020=2020-ті
 [FogOfWar]
 All=Все
 AlliesOnly=Тільки союзники
-KnownUnitsOnly=Лише відомі одиниці
-SelfOnly=Тільки я
+KnownUnitsOnly=Тільки відомі юніти
+SelfOnly=Тільки свої
+PlayerSettings=Налаштування гравця
 
 [ObjectiveOption]
 EmbeddedAirDefense=Вбудований ППО

--- a/Database/ObjectivePresets/EscortFerry.ini
+++ b/Database/ObjectivePresets/EscortFerry.ini
@@ -1,0 +1,9 @@
+[GUI]
+DisplayName=Escort Ferry Flight
+Category=Air-To-Air
+Description=Protect friendly aircraft transiting between airbases.
+
+[ObjectivePreset]
+Targets=PlaneAny
+TargetsBehaviors=RelocateBetweenAirbases,RecoverFromAirbaseToPlayerBase
+Task=EscortFerry

--- a/Database/ObjectivePresets/EscortGroundForces.ini
+++ b/Database/ObjectivePresets/EscortGroundForces.ini
@@ -5,5 +5,5 @@ Description=Escort Ground Forces to their destination.
 
 [ObjectivePreset]
 Targets=VehicleAny
-TargetsBehaviors=PatrollingOnRoads
+TargetsBehaviors=PatrollingOnRoads,ToFrontLineOnRoads,RecoverToPlayerBaseOnRoads,GoToBaseOnRoads,RelocateToNewPositionOnRoads
 Task=Escort

--- a/Database/ObjectivePresets/EscortHVA.ini
+++ b/Database/ObjectivePresets/EscortHVA.ini
@@ -1,0 +1,9 @@
+[GUI]
+DisplayName=Escort High Value Asset
+Category=Air-To-Air
+Description=Protect friendly AWACS or Tanker aircraft.
+
+[ObjectivePreset]
+Targets=PlaneAWACS,PlaneTanker
+TargetsBehaviors=Patrolling,IdleCAP
+Task=EscortHVA

--- a/Database/ObjectivePresets/EscortHelicopters.ini
+++ b/Database/ObjectivePresets/EscortHelicopters.ini
@@ -5,5 +5,5 @@ Description=Escort Helicopters to their destination.
 
 [ObjectivePreset]
 Targets=HelicopterAny
-TargetsBehaviors=Patrolling
-Task=Escort
+TargetsBehaviors=Patrolling,ToFrontLineFromAirbase,RelocateBetweenAirbases,RecoverFromAirbaseToPlayerBase
+Task=EscortHelicopter

--- a/Database/ObjectivePresets/EscortPlane.ini
+++ b/Database/ObjectivePresets/EscortPlane.ini
@@ -6,4 +6,4 @@ Description=Escort Planes to their destination.
 [ObjectivePreset]
 Targets=PlaneAny
 TargetsBehaviors=Patrolling
-Task=Escort
+Task=EscortPlane

--- a/Database/ObjectiveTargetsBehaviors/AttackObjective.ini
+++ b/Database/ObjectiveTargetsBehaviors/AttackObjective.ini
@@ -1,0 +1,26 @@
+[GUI]
+DisplayName=Attack Objective
+Category=Moving
+Description=Target aircraft will fly from a friendly airbase and attack the objective.
+
+[Behavior]
+Location=PlayerAirbase
+Destination=Default
+ValidUnitCategories=Plane,Helicopter
+InValidTasks=ExtractTroops,TransportTroops,TransportCargo,TransportDynamicCargo,CaptureLocation
+IsStatic=false
+
+[Lua]
+Group.Helicopter=AircraftBomb
+Group.Plane=AircraftBomb
+Group.Ship=ShipMoving
+Group.Static=Static
+Group.Cargo=Static
+Group.Vehicle=VehicleMovingOffRoad
+
+Unit.Helicopter=Aircraft
+Unit.Plane=Aircraft
+Unit.Ship=Ship
+Unit.Static=Static
+Unit.Cargo=Cargo
+Unit.Vehicle=Vehicle

--- a/Database/ObjectiveTargetsBehaviors/AttackObjectiveFromAir.ini
+++ b/Database/ObjectiveTargetsBehaviors/AttackObjectiveFromAir.ini
@@ -1,0 +1,26 @@
+[GUI]
+DisplayName=Attack Objective (From Air)
+Category=Moving
+Description=Target aircraft will spawn in the air and attack the objective.
+
+[Behavior]
+Location=NearAirbase
+Destination=Default
+ValidUnitCategories=Plane,Helicopter
+InValidTasks=ExtractTroops,TransportTroops,TransportCargo,TransportDynamicCargo,CaptureLocation
+IsStatic=false
+
+[Lua]
+Group.Helicopter=AircraftBomb
+Group.Plane=AircraftBomb
+Group.Ship=ShipMoving
+Group.Static=Static
+Group.Cargo=Static
+Group.Vehicle=VehicleMovingOffRoad
+
+Unit.Helicopter=Aircraft
+Unit.Plane=Aircraft
+Unit.Ship=Ship
+Unit.Static=Static
+Unit.Cargo=Cargo
+Unit.Vehicle=Vehicle

--- a/Database/ObjectiveTargetsBehaviors/AttackObjectiveFromAirbase.ini
+++ b/Database/ObjectiveTargetsBehaviors/AttackObjectiveFromAirbase.ini
@@ -1,0 +1,26 @@
+[GUI]
+DisplayName=Attack Objective (From Any Airbase)
+Category=Moving
+Description=Target aircraft will fly from any friendly airbase and attack the objective.
+
+[Behavior]
+Location=Airbase
+Destination=Default
+ValidUnitCategories=Plane,Helicopter
+InValidTasks=ExtractTroops,TransportTroops,TransportCargo,TransportDynamicCargo,CaptureLocation
+IsStatic=false
+
+[Lua]
+Group.Helicopter=AircraftBomb
+Group.Plane=AircraftBomb
+Group.Ship=ShipMoving
+Group.Static=Static
+Group.Cargo=Static
+Group.Vehicle=VehicleMovingOffRoad
+
+Unit.Helicopter=Aircraft
+Unit.Plane=Aircraft
+Unit.Ship=Ship
+Unit.Static=Static
+Unit.Cargo=Cargo
+Unit.Vehicle=Vehicle

--- a/Database/ObjectiveTargetsBehaviors/InsertAtObjective.ini
+++ b/Database/ObjectiveTargetsBehaviors/InsertAtObjective.ini
@@ -1,0 +1,26 @@
+[GUI]
+DisplayName=Insert At Objective
+Category=Moving
+Description=Target transport will fly from a friendly airbase and land at the objective.
+
+[Behavior]
+Location=PlayerAirbase
+Destination=Default
+ValidUnitCategories=Plane,Helicopter
+InValidTasks=DefendAttack,DestroyTrackingRadars,DestroyAll,Disable,CaptureLocation
+IsStatic=false
+
+[Lua]
+Group.Helicopter=AircraftLanding
+Group.Plane=AircraftLanding
+Group.Ship=ShipMoving
+Group.Static=Static
+Group.Cargo=Static
+Group.Vehicle=VehicleMovingOffRoad
+
+Unit.Helicopter=Aircraft
+Unit.Plane=Aircraft
+Unit.Ship=Ship
+Unit.Static=Static
+Unit.Cargo=Cargo
+Unit.Vehicle=Vehicle

--- a/Database/ObjectiveTargetsBehaviors/InsertAtObjectiveFromAir.ini
+++ b/Database/ObjectiveTargetsBehaviors/InsertAtObjectiveFromAir.ini
@@ -1,0 +1,26 @@
+[GUI]
+DisplayName=Insert At Objective (From Air)
+Category=Moving
+Description=Target transport will spawn in the air and land at the objective.
+
+[Behavior]
+Location=NearAirbase
+Destination=Default
+ValidUnitCategories=Plane,Helicopter
+InValidTasks=DefendAttack,DestroyTrackingRadars,DestroyAll,Disable,CaptureLocation
+IsStatic=false
+
+[Lua]
+Group.Helicopter=AircraftLanding
+Group.Plane=AircraftLanding
+Group.Ship=ShipMoving
+Group.Static=Static
+Group.Cargo=Static
+Group.Vehicle=VehicleMovingOffRoad
+
+Unit.Helicopter=Aircraft
+Unit.Plane=Aircraft
+Unit.Ship=Ship
+Unit.Static=Static
+Unit.Cargo=Cargo
+Unit.Vehicle=Vehicle

--- a/Database/ObjectiveTargetsBehaviors/InsertAtObjectiveFromAirbase.ini
+++ b/Database/ObjectiveTargetsBehaviors/InsertAtObjectiveFromAirbase.ini
@@ -1,0 +1,26 @@
+[GUI]
+DisplayName=Insert At Objective (From Any Airbase)
+Category=Moving
+Description=Target transport will fly from any friendly airbase and land at the objective.
+
+[Behavior]
+Location=Airbase
+Destination=Default
+ValidUnitCategories=Plane,Helicopter
+InValidTasks=DefendAttack,DestroyTrackingRadars,DestroyAll,Disable,CaptureLocation
+IsStatic=false
+
+[Lua]
+Group.Helicopter=AircraftLanding
+Group.Plane=AircraftLanding
+Group.Ship=ShipMoving
+Group.Static=Static
+Group.Cargo=Static
+Group.Vehicle=VehicleMovingOffRoad
+
+Unit.Helicopter=Aircraft
+Unit.Plane=Aircraft
+Unit.Ship=Ship
+Unit.Static=Static
+Unit.Cargo=Cargo
+Unit.Vehicle=Vehicle

--- a/Database/ObjectiveTargetsBehaviors/ReconObjective.ini
+++ b/Database/ObjectiveTargetsBehaviors/ReconObjective.ini
@@ -1,0 +1,26 @@
+[GUI]
+DisplayName=Recon Objective
+Category=Moving
+Description=Target aircraft will fly from a friendly airbase to the objective.
+
+[Behavior]
+Location=PlayerAirbase
+Destination=Default
+ValidUnitCategories=Plane,Helicopter
+InValidTasks=ExtractTroops,TransportTroops,TransportCargo,TransportDynamicCargo,CaptureLocation
+IsStatic=false
+
+[Lua]
+Group.Helicopter=AircraftMoving
+Group.Plane=AircraftMoving
+Group.Ship=ShipMoving
+Group.Static=Static
+Group.Cargo=Static
+Group.Vehicle=VehicleMovingOffRoad
+
+Unit.Helicopter=Aircraft
+Unit.Plane=Aircraft
+Unit.Ship=Ship
+Unit.Static=Static
+Unit.Cargo=Cargo
+Unit.Vehicle=Vehicle

--- a/Database/ObjectiveTargetsBehaviors/ReconObjectiveFromAir.ini
+++ b/Database/ObjectiveTargetsBehaviors/ReconObjectiveFromAir.ini
@@ -1,0 +1,26 @@
+[GUI]
+DisplayName=Recon Objective (From Air)
+Category=Moving
+Description=Target aircraft will spawn in the air and fly to the objective.
+
+[Behavior]
+Location=NearAirbase
+Destination=Default
+ValidUnitCategories=Plane,Helicopter
+InValidTasks=ExtractTroops,TransportTroops,TransportCargo,TransportDynamicCargo,CaptureLocation
+IsStatic=false
+
+[Lua]
+Group.Helicopter=AircraftMoving
+Group.Plane=AircraftMoving
+Group.Ship=ShipMoving
+Group.Static=Static
+Group.Cargo=Static
+Group.Vehicle=VehicleMovingOffRoad
+
+Unit.Helicopter=Aircraft
+Unit.Plane=Aircraft
+Unit.Ship=Ship
+Unit.Static=Static
+Unit.Cargo=Cargo
+Unit.Vehicle=Vehicle

--- a/Database/ObjectiveTargetsBehaviors/ReconObjectiveFromAirbase.ini
+++ b/Database/ObjectiveTargetsBehaviors/ReconObjectiveFromAirbase.ini
@@ -1,0 +1,26 @@
+[GUI]
+DisplayName=Recon Objective (From Any Airbase)
+Category=Moving
+Description=Target aircraft will fly from any friendly airbase to the objective.
+
+[Behavior]
+Location=Airbase
+Destination=Default
+ValidUnitCategories=Plane,Helicopter
+InValidTasks=ExtractTroops,TransportTroops,TransportCargo,TransportDynamicCargo,CaptureLocation
+IsStatic=false
+
+[Lua]
+Group.Helicopter=AircraftMoving
+Group.Plane=AircraftMoving
+Group.Ship=ShipMoving
+Group.Static=Static
+Group.Cargo=Static
+Group.Vehicle=VehicleMovingOffRoad
+
+Unit.Helicopter=Aircraft
+Unit.Plane=Aircraft
+Unit.Ship=Ship
+Unit.Static=Static
+Unit.Cargo=Cargo
+Unit.Vehicle=Vehicle

--- a/Database/ObjectiveTasks/Escort.ini
+++ b/Database/ObjectiveTasks/Escort.ini
@@ -5,14 +5,14 @@ Description=Watch over friendly forces moving position
 
 [Briefing]
 Description=Escort
-Task.Singular=Watch over friendly forces moving from $OBJECTIVENAME$ Pickup to objective $OBJECTIVENAME$.
-Task.Plural=Watch over friendly forces moving from $OBJECTIVENAME$ Pickup to objective $OBJECTIVENAME$.
+Task.Singular=Watch over friendly $ESCORTGROUPNAME$ ($UNITDISPLAYNAME$) moving from $OBJECTIVENAME$ Pickup to objective $OBJECTIVENAME$$ESCORTALTITUDECLAUSE$.
+Task.Plural=Watch over friendly $ESCORTGROUPNAME$ ($UNITDISPLAYNAME$) moving from $OBJECTIVENAME$ Pickup to objective $OBJECTIVENAME$$ESCORTALTITUDECLAUSE$.
 Remarks=Forces must get within 500m of objective. Aircraft won't launch untill called to.
 
 [ObjectiveTask]
 CompletionTriggersLua=EscortNear,KeepAlive
 TargetSide=Ally
-ValidUnitCategories=Helicopter,Plane,Ship,Vehicle,Infantry
+ValidUnitCategories=Ship,Vehicle,Infantry
 
 [Include]
 Ogg=RadioPilotEscortComplete,RadioPilotBeginEscort,RadioEscortMoving

--- a/Database/ObjectiveTasks/EscortFerry.ini
+++ b/Database/ObjectiveTasks/EscortFerry.ini
@@ -1,0 +1,19 @@
+[GUI]
+DisplayName=Escort Ferry Flight
+Category=Escort
+Description=Protect friendly aircraft transiting between airbases
+
+[Briefing]
+Description=Escort
+Task.Singular=Protect friendly $ESCORTGROUPNAME$ ($UNITDISPLAYNAME$) transiting to objective $OBJECTIVENAME$$ESCORTALTITUDECLAUSE$.
+Task.Plural=Protect friendly $ESCORTGROUPNAME$ ($UNITDISPLAYNAME$) transiting to objective $OBJECTIVENAME$$ESCORTALTITUDECLAUSE$.
+Remarks=Aircraft won't launch untill called to.
+
+[ObjectiveTask]
+CompletionTriggersLua=EscortNear,KeepAlive
+TargetSide=Ally
+ValidUnitCategories=Plane
+ValidPlayerUnitCategories=Plane
+
+[Include]
+Ogg=RadioPilotEscortComplete,RadioPilotBeginEscort,RadioEscortMoving

--- a/Database/ObjectiveTasks/EscortHVA.ini
+++ b/Database/ObjectiveTasks/EscortHVA.ini
@@ -1,0 +1,19 @@
+[GUI]
+DisplayName=Escort High Value Asset
+Category=Escort
+Description=Protect friendly AWACS or Tanker aircraft
+
+[Briefing]
+Description=Escort
+Task.Singular=Protect friendly High Value Asset $ESCORTGROUPNAME$ ($UNITDISPLAYNAME$) operating near objective $OBJECTIVENAME$$ESCORTALTITUDECLAUSE$.
+Task.Plural=Protect friendly High Value Assets $ESCORTGROUPNAME$ ($UNITDISPLAYNAME$) operating near objective $OBJECTIVENAME$$ESCORTALTITUDECLAUSE$.
+Remarks=Aircraft won't launch untill called to.
+
+[ObjectiveTask]
+CompletionTriggersLua=EscortNear,KeepAlive
+TargetSide=Ally
+ValidUnitCategories=Plane
+ValidPlayerUnitCategories=Plane
+
+[Include]
+Ogg=RadioPilotEscortComplete,RadioPilotBeginEscort,RadioEscortMoving

--- a/Database/ObjectiveTasks/EscortHelicopter.ini
+++ b/Database/ObjectiveTasks/EscortHelicopter.ini
@@ -1,0 +1,19 @@
+[GUI]
+DisplayName=Escort (Helicopter)
+Category=Escort
+Description=Watch over friendly helicopter forces
+
+[Briefing]
+Description=Escort
+Task.Singular=Watch over friendly $ESCORTGROUPNAME$ ($UNITDISPLAYNAME$) moving to objective $OBJECTIVENAME$$ESCORTALTITUDECLAUSE$.
+Task.Plural=Watch over friendly $ESCORTGROUPNAME$ ($UNITDISPLAYNAME$) moving to objective $OBJECTIVENAME$$ESCORTALTITUDECLAUSE$.
+Remarks=Aircraft won't launch untill called to.
+
+[ObjectiveTask]
+CompletionTriggersLua=EscortNear,KeepAlive
+TargetSide=Ally
+ValidUnitCategories=Helicopter
+ValidPlayerUnitCategories=Helicopter,Plane
+
+[Include]
+Ogg=RadioPilotEscortComplete,RadioPilotBeginEscort,RadioEscortMoving

--- a/Database/ObjectiveTasks/EscortPlane.ini
+++ b/Database/ObjectiveTasks/EscortPlane.ini
@@ -1,0 +1,19 @@
+[GUI]
+DisplayName=Escort (Fixed Wing)
+Category=Escort
+Description=Watch over friendly fixed-wing forces
+
+[Briefing]
+Description=Escort
+Task.Singular=Watch over friendly $ESCORTGROUPNAME$ ($UNITDISPLAYNAME$) moving to objective $OBJECTIVENAME$$ESCORTALTITUDECLAUSE$.
+Task.Plural=Watch over friendly $ESCORTGROUPNAME$ ($UNITDISPLAYNAME$) moving to objective $OBJECTIVENAME$$ESCORTALTITUDECLAUSE$.
+Remarks=Aircraft won't launch untill called to.
+
+[ObjectiveTask]
+CompletionTriggersLua=EscortNear,KeepAlive
+TargetSide=Ally
+ValidUnitCategories=Plane
+ValidPlayerUnitCategories=Plane
+
+[Include]
+Ogg=RadioPilotEscortComplete,RadioPilotBeginEscort,RadioEscortMoving

--- a/Database/OptionsMission/StrictEscortDamageThreshold.ini
+++ b/Database/OptionsMission/StrictEscortDamageThreshold.ini
@@ -1,0 +1,3 @@
+[GUI]
+DisplayName=Strict Escort Fail Conditions
+Description=Escort missions fail if the escorted VIP takes any damage at all.

--- a/Include/Lua/Mission/Script/DCSExtensions.lua
+++ b/Include/Lua/Mission/Script/DCSExtensions.lua
@@ -84,6 +84,7 @@ function dcsExtensions.isUnitAlive(name)
 end
 
 function dcsExtensions.getUnitOrStatic(name)
+  if name == nil then return nil end
   local unit = Unit.getByName(name)
   if unit == nil then -- no unit found with the ID, try searching for a static
     unit = StaticObject.getByName(name)

--- a/Include/Lua/Mission/Script/MissionTriggers/KeepUndamaged.lua
+++ b/Include/Lua/Mission/Script/MissionTriggers/KeepUndamaged.lua
@@ -1,0 +1,49 @@
+function briefingRoom.mission.objectivesTriggersCommon.registerKeepUndamagedTrigger(objectiveIndex)
+  local handler = function(event)
+    -- Mission complete, nothing to do
+    if briefingRoom.mission.objectivesTriggersCommon.isMissionOrObjectiveComplete(objectiveIndex) then return false end
+
+    local hitOrDestroyedUnit = nil
+    
+    if event.id == world.event.S_EVENT_DEAD or event.id == world.event.S_EVENT_CRASH then
+        hitOrDestroyedUnit = event.initiator
+    elseif event.id == world.event.S_EVENT_HIT or event.id == world.event.S_EVENT_KILL then
+        hitOrDestroyedUnit = event.target
+    elseif briefingRoom.mission.objectives[objectiveIndex].targetCategory == Unit.Category.HELICOPTER and event.id == world.event.S_EVENT_LAND then
+        hitOrDestroyedUnit = event.initiator
+    end
+    
+    if hitOrDestroyedUnit == nil then return false end
+    
+    if Object.getCategory(hitOrDestroyedUnit) ~= Object.Category.UNIT and Object.getCategory(hitOrDestroyedUnit) ~= Object.Category.STATIC then return false end
+    if hitOrDestroyedUnit.getName == nil then return false end
+  
+    local unitName = hitOrDestroyedUnit:getName()
+    -- Destroyed/Hit unit wasn't a target
+    if not briefingRoom.mission.objectivesTriggersCommon.objectiveHasUnitName(objectiveIndex, unitName) then return false end
+  
+    -- Remove the unit from the list of targets
+    briefingRoom.mission.objectivesTriggersCommon.removeObjectiveUnitName(objectiveIndex, unitName)
+  
+    -- Play "target destroyed" radio message
+    local messages = { "$LANG_COMMAND$: $LANG_TARGETLOST1$", "$LANG_COMMAND$: $LANG_TARGETLOST2$" }
+    local messageIndex = math.random(1, 2)
+  
+    if briefingRoom.eventHandler.BDASetting == "ALL" or briefingRoom.eventHandler.BDASetting == "TARGETONLY" then
+      briefingRoom.radioManager.play(messages[messageIndex], "RadioHQTargetLost", math.random(1, 3))
+    end
+  
+    -- Mark the objective as failed (or complete in this context means failed since it's an escort?)
+    -- In KeepAlive, removing all target units completes the objective but marks it failed?
+    -- Wait, if any unit takes damage, we fail the entire objective.
+    briefingRoom.mission.coreFunctions.completeObjective(objectiveIndex, true)
+  
+    return true
+  end
+
+  briefingRoom.mission.registerObjectiveEventTrigger(world.event.S_EVENT_HIT, handler)
+  briefingRoom.mission.registerObjectiveEventTrigger(world.event.S_EVENT_KILL, handler)
+  briefingRoom.mission.registerObjectiveEventTrigger(world.event.S_EVENT_DEAD, handler)
+  briefingRoom.mission.registerObjectiveEventTrigger(world.event.S_EVENT_CRASH, handler)
+  briefingRoom.mission.registerObjectiveEventTrigger(world.event.S_EVENT_LAND, handler)
+end

--- a/Include/Lua/Mission/Script/ObjectiveFeatures/StartAttack.lua
+++ b/Include/Lua/Mission/Script/ObjectiveFeatures/StartAttack.lua
@@ -1,7 +1,7 @@
 function briefingRoom.mission.objectivesTriggersCommon.startAttack(args)
     local objectiveIndex = args[1]
+    local groupNames = args[2]
     briefingRoom.radioManager.play("$LANG_PILOT$: $LANG_LAUNCHATTACKREQUEST$", "RadioPilotBeginYourAttack")
-    local groupNames = dcsExtensions.getGroupNamesContaining("%-STGT%-$OBJECTIVENAME$")
     briefingRoom.debugPrint("Activating Attack group objectiveIndex: " .. table.count(groupNames), 1)
     for _, value in pairs(groupNames) do
         local acGroup = Group.getByName(value) -- get the group
@@ -21,9 +21,9 @@ function briefingRoom.mission.objectivesTriggersCommon.startAttack(args)
         briefingRoom.mission.objectives[objectiveIndex].f10Commands[idx].commandPath)
 end
 
-function briefingRoom.mission.objectiveFeaturesCommon.registerStartAttack(objectiveIndex)
+function briefingRoom.mission.objectiveFeaturesCommon.registerStartAttack(objectiveIndex, groupNames)
     table.insert(briefingRoom.mission.objectives[objectiveIndex].f10Commands,
-        { text = "$LANG_LAUNCHATTACK$", func = briefingRoom.mission.objectivesTriggersCommon.startAttack, args = { objectiveIndex } })
+        { text = "$LANG_LAUNCHATTACK$", func = briefingRoom.mission.objectivesTriggersCommon.startAttack, args = { objectiveIndex, groupNames } })
     briefingRoom.mission.objectiveFeatures[objectiveIndex].startAttackCommandIndex = table.count(briefingRoom.mission
     .objectives[objectiveIndex].f10Commands)
 end

--- a/Include/Lua/ObjectiveFeatures/StartAttack.lua
+++ b/Include/Lua/ObjectiveFeatures/StartAttack.lua
@@ -1,1 +1,1 @@
-briefingRoom.mission.objectiveFeaturesCommon.registerStartAttack($OBJECTIVEINDEX$)
+briefingRoom.mission.objectiveFeaturesCommon.registerStartAttack($OBJECTIVEINDEX$, $SUPPORTINGTARGETGROUPNAMES$)

--- a/Include/Lua/ObjectiveTriggers/KeepUndamaged.lua
+++ b/Include/Lua/ObjectiveTriggers/KeepUndamaged.lua
@@ -1,0 +1,1 @@
+briefingRoom.mission.objectivesTriggersCommon.registerKeepUndamagedTrigger($OBJECTIVEINDEX$)

--- a/src/BriefingRoom/BriefingRoom.cs
+++ b/src/BriefingRoom/BriefingRoom.cs
@@ -91,7 +91,13 @@ namespace BriefingRoom4DCS
                     if (string.IsNullOrEmpty(parameter)) // No parameter, return none
                         return (from DBEntryObjectiveTarget objectiveTarget in Database.GetAllEntries<DBEntryObjectiveTarget>() select objectiveTarget.GetDBEntryInfo()).OrderBy(x => x.Name.Get(LanguageKey)).ToArray();
                     else
-                        return (from DBEntryObjectiveTarget objectiveTarget in Database.GetAllEntries<DBEntryObjectiveTarget>() where Database.GetEntry<DBEntryObjectiveTask>(parameter).ValidUnitCategories.Contains(objectiveTarget.UnitCategory) select objectiveTarget.GetDBEntryInfo()).OrderBy(x => x.Name.Get(LanguageKey)).ToArray();
+                    {
+                        var taskDB = Database.GetEntry<DBEntryObjectiveTask>(parameter);
+                        return (from DBEntryObjectiveTarget objectiveTarget in Database.GetAllEntries<DBEntryObjectiveTarget>() 
+                                where taskDB.ValidUnitCategories.Contains(objectiveTarget.UnitCategory) && 
+                                      (taskDB.ValidTargetIDs.Length == 0 || taskDB.ValidTargetIDs.Contains(objectiveTarget.ID)) 
+                                select objectiveTarget.GetDBEntryInfo()).OrderBy(x => x.Name.Get(LanguageKey)).ToArray();
+                    }
                 case DatabaseEntryType.ObjectiveTargetBehavior:
                     if (string.IsNullOrEmpty(parameter)) // No parameter, return none
                         return (from DBEntryObjectiveTargetBehavior objectiveTargetBehavior in Database.GetAllEntries<DBEntryObjectiveTargetBehavior>() select objectiveTargetBehavior.GetDBEntryInfo()).OrderBy(x => x.Name.Get(LanguageKey)).ToArray();

--- a/src/BriefingRoom/Data/Entries/DBEntryObjectiveTask.cs
+++ b/src/BriefingRoom/Data/Entries/DBEntryObjectiveTask.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ==========================================================================
 This file is part of Briefing Room for DCS World, a mission
 generator for DCS World, by @akaAgar (https://github.com/akaAgar/briefing-room-for-dcs)
@@ -79,7 +79,7 @@ namespace BriefingRoom4DCS.Data
             return true;
         }
 
-        internal bool IsEscort() => ID == "Escort";
+        internal bool IsEscort() => ID.StartsWith("Escort") || ID == "SupportStrike" || ID == "SupportRecon" || ID == "SupportTransport";
         internal bool IsHoldSuperiority() => ID == "HoldSuperiority";
     }
 }

--- a/src/BriefingRoom/Generator/CampaignGenerator.cs
+++ b/src/BriefingRoom/Generator/CampaignGenerator.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ==========================================================================
 This file is part of Briefing Room for DCS World, a mission
 generator for DCS World, by @akaAgar (https://github.com/akaAgar/briefing-room-for-dcs)
@@ -368,6 +368,8 @@ namespace BriefingRoom4DCS.Generator
             if (targetDB == null || targetBehaviorDB == null || taskDB == null)
                 return false;
             if (!taskDB.ValidUnitCategories.Contains(targetDB.UnitCategory))
+                return false;
+            if (taskDB.ValidTargetIDs.Length > 0 && !taskDB.ValidTargetIDs.Contains(targetDB.ID))
                 return false;
             if (!targetBehaviorDB.ValidUnitCategories.Contains(targetDB.UnitCategory))
                 return false;

--- a/src/BriefingRoom/Generator/MissionGenerator/Features.cs
+++ b/src/BriefingRoom/Generator/MissionGenerator/Features.cs
@@ -175,21 +175,46 @@ namespace BriefingRoom4DCS.Generator.Mission
                 if (
                     groupSide == Side.Ally &&
                     groupInfo.HasValue &&
-                    groupInfo.Value.UnitDB != null &&
-                    groupInfo.Value.UnitDB.IsAircraft &&
-                    !flags.HasFlag(FeatureUnitGroupFlags.StaticAircraft))
-                    mission.Briefing.AddItem(DCSMissionBriefingItemType.FlightGroup,
-                            $"{groupInfo.Value.Name.Split("-")[0]}{(featureDB.GetDBEntryInfo().Category.Get("en") == "Direct Support" ? "(DS)" : "")}\t" +
-                            $"{unitCount}× {groupInfo.Value.UnitDB.UIDisplayName.Get(mission.LangKey)}\t" +
-                            $"{GeneratorTools.FormatRadioFrequency(groupInfo.Value.Frequency)}{TACANStr}\t" +
-                            $"{featureDB.UnitGroupTask}" +
-                            (airbaseName != null ? $"\t{airbaseName}" : "") +
-                            (airbaseName != null ? $"\t{airbaseName}" : ""));
+                    groupInfo.Value.UnitDB != null)
+                {
+                    if (groupInfo.Value.UnitDB.IsAircraft && !flags.HasFlag(FeatureUnitGroupFlags.StaticAircraft))
+                    {
+                        mission.Briefing.AddItem(DCSMissionBriefingItemType.FlightGroup,
+                                $"{groupInfo.Value.Name.Split("-")[0]}{(featureDB.GetDBEntryInfo().Category.Get("en") == "Direct Support" ? "(DS)" : "")}\t" +
+                                $"{unitCount}× {groupInfo.Value.UnitDB.UIDisplayName.Get(mission.LangKey)}\t" +
+                                $"{GeneratorTools.FormatRadioFrequency(groupInfo.Value.Frequency)}{TACANStr}\t" +
+                                $"{featureDB.UnitGroupTask}" +
+                                (airbaseName != null ? $"\t{airbaseName}" : "") +
+                                (airbaseName != null ? $"\t{airbaseName}" : ""));
+                    }
+                    else if (!groupInfo.Value.UnitDB.IsAircraft)
+                    {
+                        var isNearObjective = mission.ObjectiveCoordinates.Count == 0 || mission.ObjectiveCoordinates.Any(x => x.GetDistanceFrom(groupInfo.Value.Coordinates) < 15 * Toolbox.NM_TO_METERS);
+                        if (isNearObjective)
+                        {
+                            var friendlyForcesListStr = briefingRoom.Database.Language.Translate(mission.LangKey, "FriendlyForcesList");
+                            mission.Briefing.AddItem(DCSMissionBriefingItemType.Remark, $"{friendlyForcesListStr}: {groupInfo.Value.Name.Split("-")[0]} ({unitCount}× {groupInfo.Value.UnitDB.UIDisplayName.Get(mission.LangKey)})");
+
+                            if (mission.TemplateRecord.OptionsMission.Contains("MarkWaypoints"))
+                            {
+                                var friendlyForcesLabelStr = briefingRoom.Database.Language.Translate(mission.LangKey, "FriendlyForcesLabel");
+                                DrawingMaker.AddDrawing(ref mission, $"Friendly Forces Area {groupInfo.Value.Name}", DrawingType.Circle, groupInfo.Value.Coordinates, "Radius".ToKeyValuePair(1.0 * Toolbox.NM_TO_METERS), "Colour".ToKeyValuePair(DrawingColour.Blue));
+                                DrawingMaker.AddDrawing(ref mission, $"Friendly Forces Text {groupInfo.Value.Name}", DrawingType.TextBox, groupInfo.Value.Coordinates, "Text".ToKeyValuePair($"{friendlyForcesLabelStr} {groupInfo.Value.Name.Split("-")[0]}"), "Colour".ToKeyValuePair(DrawingColour.Blue), "FillColour".ToKeyValuePair(DrawingColour.Clear));
+                            }
+                        }
+                    }
+                }
                 if (!groupInfo.Value.UnitDB.IsAircraft)
                     mission.MapData.Add($"UNIT-{groupInfo.Value.UnitDB.Families[0]}-{groupSide}-{groupInfo.Value.GroupID}", new List<double[]> { groupInfo.Value.Coordinates.ToArray() });
 
                 if (featureDB.ExtraGroups.Max > 1)
                     SpawnExtraGroups(briefingRoom, featureDB, ref mission, groupSide, groupFlags, coordinatesValue, coordinates2.Value, extraSettings);
+
+                if (extraSettings.ContainsKey("SUPPORTINGTARGETGROUPNAMES"))
+                {
+                    var namesList = (List<string>)extraSettings["SUPPORTINGTARGETGROUPNAMES"];
+                    extraSettings["SUPPORTINGTARGETGROUPNAMES"] = "{" + string.Join(", ", namesList) + "}";
+                }
             }
 
             // Feature Lua script
@@ -404,16 +429,35 @@ namespace BriefingRoom4DCS.Generator.Mission
                 if (
                    groupSide == Side.Ally &&
                    groupInfo.HasValue &&
-                   groupInfo.Value.UnitDB != null &&
-                   groupInfo.Value.UnitDB.IsAircraft &&
-                   !flags.HasFlag(FeatureUnitGroupFlags.StaticAircraft))
-                    mission.Briefing.AddItem(DCSMissionBriefingItemType.FlightGroup,
-                            $"{groupInfo.Value.Name.Split("-")[0]}\t" +
-                            $"{unitCount}× {groupInfo.Value.UnitDB.UIDisplayName.Get(mission.LangKey)}\t" +
-                            $"{GeneratorTools.FormatRadioFrequency(groupInfo.Value.Frequency)}\t" +
-                            $"{featureDB.UnitGroupTask}" +
-                            (airbaseName != null ? $"\t{airbaseName}" : "") +
-                            (airbaseName != null ? $"{airbaseName}" : ""));
+                   groupInfo.Value.UnitDB != null)
+                {
+                    if (groupInfo.Value.UnitDB.IsAircraft && !flags.HasFlag(FeatureUnitGroupFlags.StaticAircraft))
+                    {
+                        mission.Briefing.AddItem(DCSMissionBriefingItemType.FlightGroup,
+                                $"{groupInfo.Value.Name.Split("-")[0]}\t" +
+                                $"{unitCount}× {groupInfo.Value.UnitDB.UIDisplayName.Get(mission.LangKey)}\t" +
+                                $"{GeneratorTools.FormatRadioFrequency(groupInfo.Value.Frequency)}\t" +
+                                $"{featureDB.UnitGroupTask}" +
+                                (airbaseName != null ? $"\t{airbaseName}" : "") +
+                                (airbaseName != null ? $"{airbaseName}" : ""));
+                    }
+                    else if (!groupInfo.Value.UnitDB.IsAircraft)
+                    {
+                        var isNearObjective = mission.ObjectiveCoordinates.Count == 0 || mission.ObjectiveCoordinates.Any(x => x.GetDistanceFrom(groupInfo.Value.Coordinates) < 15 * Toolbox.NM_TO_METERS);
+                        if (isNearObjective)
+                        {
+                            var friendlyForcesListStr = briefingRoom.Database.Language.Translate(mission.LangKey, "FriendlyForcesList");
+                            mission.Briefing.AddItem(DCSMissionBriefingItemType.Remark, $"{friendlyForcesListStr}: {groupInfo.Value.Name.Split("-")[0]} ({unitCount}× {groupInfo.Value.UnitDB.UIDisplayName.Get(mission.LangKey)})");
+
+                            if (mission.TemplateRecord.OptionsMission.Contains("MarkWaypoints"))
+                            {
+                                var friendlyForcesLabelStr = briefingRoom.Database.Language.Translate(mission.LangKey, "FriendlyForcesLabel");
+                                DrawingMaker.AddDrawing(ref mission, $"Friendly Forces Area {groupInfo.Value.Name}", DrawingType.Circle, groupInfo.Value.Coordinates, "Radius".ToKeyValuePair(1.0 * Toolbox.NM_TO_METERS), "Colour".ToKeyValuePair(DrawingColour.Blue));
+                                DrawingMaker.AddDrawing(ref mission, $"Friendly Forces Text {groupInfo.Value.Name}", DrawingType.TextBox, groupInfo.Value.Coordinates, "Text".ToKeyValuePair($"{friendlyForcesLabelStr} {groupInfo.Value.Name.Split("-")[0]}"), "Colour".ToKeyValuePair(DrawingColour.Blue), "FillColour".ToKeyValuePair(DrawingColour.Clear));
+                            }
+                        }
+                    }
+                }
                 if (!groupInfo.Value.UnitDB.IsAircraft)
                     mission.MapData.Add($"UNIT-{groupInfo.Value.UnitDB.Families[0]}-{groupSide}-{groupInfo.Value.GroupID}", new List<double[]> { groupInfo.Value.Coordinates.ToArray() });
             }
@@ -485,7 +529,17 @@ namespace BriefingRoom4DCS.Generator.Mission
         private static void SetSupportingTargetGroupName(ref GroupInfo? groupInfo, FeatureUnitGroupFlags flags, Dictionary<string, object> extraSettings)
         {
             if (flags.HasFlag(FeatureUnitGroupFlags.SupportingTarget))
-                groupInfo.Value.DCSGroups.ForEach(x => x.Name += $"-STGT-{extraSettings["ObjectiveName"]}");
+            {
+                if (!extraSettings.ContainsKey("SUPPORTINGTARGETGROUPNAMES"))
+                    extraSettings.Add("SUPPORTINGTARGETGROUPNAMES", new List<string>());
+
+                var namesList = (List<string>)extraSettings["SUPPORTINGTARGETGROUPNAMES"];
+                groupInfo.Value.DCSGroups.ForEach(x => 
+                {
+                    x.Name += $"-STGT-{extraSettings["ObjectiveName"]}";
+                    namesList.Add($"'{x.Name}'");
+                });
+            }
         }
 
         private static Coordinates GetFiringCoordinates(ref DCSMission mission, Coordinates coordinates, DBEntryJSONUnit unitDB)

--- a/src/BriefingRoom/Generator/MissionGenerator/ObjectiveGenerator.cs
+++ b/src/BriefingRoom/Generator/MissionGenerator/ObjectiveGenerator.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ==========================================================================
 This file is part of Briefing Room for DCS World, a mission
 generator for DCS World, by @akaAgar (https://github.com/akaAgar/briefing-room-for-dcs)
@@ -151,9 +151,11 @@ namespace BriefingRoom4DCS.Generator.Mission
             List<UnitFamily> unitFamilies = null)
         {
             BriefingRoom.PrintToLog($"Generating objective {objectiveIndex} ...");
+            if (taskDB.IsEscort())
+                return Escort.CreateObjective(briefingRoom, task, taskDB, targetDB, targetBehaviorDB, ref objectiveIndex, ref objectiveCoords, objectiveOptions, ref mission, featuresID, unitFamilies);
+
             return taskDB.ID switch
             {
-                "Escort" => Escort.CreateObjective(briefingRoom, task, taskDB, targetDB, targetBehaviorDB, ref objectiveIndex, ref objectiveCoords, objectiveOptions, ref mission, featuresID, unitFamilies),
                 "Hold" or "HoldSuperiority" => Hold.CreateObjective(briefingRoom, task, taskDB, targetDB, targetBehaviorDB, ref objectiveIndex, ref objectiveCoords, objectiveOptions, ref mission, featuresID, unitFamilies),
                 "TransportTroops" or "TransportCargo" or "ExtractTroops" => Transport.CreateObjective(briefingRoom, task, taskDB, targetDB, targetBehaviorDB, ref objectiveIndex, ref objectiveCoords, objectiveOptions, ref mission, featuresID, unitFamilies),
                 "TransportDynamicCargo" => TransportDynamicCargo.CreateObjective(briefingRoom, task, taskDB, targetDB, targetBehaviorDB, ref objectiveIndex, ref objectiveCoords, objectiveOptions, ref mission, featuresID, unitFamilies),

--- a/src/BriefingRoom/Generator/MissionGenerator/Objectives/Escort.cs
+++ b/src/BriefingRoom/Generator/MissionGenerator/Objectives/Escort.cs
@@ -44,6 +44,27 @@ namespace BriefingRoom4DCS.Generator.Mission.Objectives
             // Get units with validation
             ObjectiveCreationHelpers.GetUnitsWithValidation(ctx);
 
+            if ((ctx.Task.Preset == "EscortPlane" || ctx.Task.Preset == "EscortHelicopters") && ctx.UnitDBs.FirstOrDefault() is DBEntryAircraft aircraftDB)
+            {
+                bool isAirSpawn = !Constants.AIRBASE_LOCATIONS.Contains(targetBehaviorDB.Location);
+                string newBehaviorId = null;
+
+                if (aircraftDB.Tasks.Contains(DCSTask.GroundAttack) || aircraftDB.Tasks.Contains(DCSTask.CAS))
+                    newBehaviorId = isAirSpawn ? "AttackObjectiveFromAir" : "AttackObjective";
+                else if (aircraftDB.Tasks.Contains(DCSTask.Reconnaissance))
+                    newBehaviorId = isAirSpawn ? "ReconObjectiveFromAir" : "ReconObjective";
+                else if (aircraftDB.Tasks.Contains(DCSTask.Transport))
+                    newBehaviorId = isAirSpawn ? "InsertAtObjectiveFromAir" : "InsertAtObjective";
+
+                if (newBehaviorId != null)
+                {
+                    targetBehaviorDB = briefingRoom.Database.GetEntry<DBEntryObjectiveTargetBehavior>(newBehaviorId);
+                    ctx.TargetBehaviorDB = targetBehaviorDB;
+                    
+                    ctx.Mission.SetValue($"DynamicBehavior_{ctx.Task.GetHashCode()}", newBehaviorId);
+                }
+            }
+
             // Get transport origin and destination for escort
             var (originAirbase, unitCoordinates) = ObjectiveTransportUtils.GetTransportOrigin(briefingRoom, ref ctx.Mission, targetBehaviorDB.Location, objectiveCoordinates, true, ctx.ObjectiveTargetUnitFamily.GetUnitCategory());
             if (Constants.AIRBASE_LOCATIONS.Contains(targetBehaviorDB.Location) && targetDB.UnitCategory.IsAircraft())
@@ -62,6 +83,24 @@ namespace BriefingRoom4DCS.Generator.Mission.Objectives
 
             ObjectiveCreationHelpers.AddAircraftSpawnFlags(ctx);
 
+            var taskType = ctx.ObjectiveTargetUnitFamily switch
+            {
+                UnitFamily.PlaneAttack or UnitFamily.PlaneBomber or UnitFamily.PlaneStrike => DCSTask.GroundAttack,
+                UnitFamily.PlaneSEAD => DCSTask.SEAD,
+                UnitFamily.HelicopterAttack => DCSTask.CAS,
+                UnitFamily.PlaneTransport or UnitFamily.HelicopterTransport or UnitFamily.HelicopterUtility => DCSTask.Transport,
+                UnitFamily.PlaneAWACS => DCSTask.AWACS,
+                UnitFamily.PlaneTankerBasket or UnitFamily.PlaneTankerBoom => DCSTask.Refueling,
+                UnitFamily.PlaneDrone => DCSTask.Reconnaissance,
+                UnitFamily.PlaneFighter or UnitFamily.PlaneInterceptor when targetBehaviorDB.ID.StartsWith("Recon") => DCSTask.Reconnaissance,
+                UnitFamily.PlaneFighter or UnitFamily.PlaneInterceptor => DCSTask.CAP,
+                _ when targetBehaviorDB.ID.StartsWith("Attack") => DCSTask.GroundAttack,
+                _ when targetBehaviorDB.ID.StartsWith("Recon") => DCSTask.Reconnaissance,
+                _ when targetBehaviorDB.ID.StartsWith("Insert") => DCSTask.Transport,
+                _ => DCSTask.Nothing
+            };
+            ctx.ExtraSettings.AddIfKeyUnused("DCSTask", taskType);
+
             var groupLua = targetBehaviorDB.GroupLua[(int)targetDB.DCSUnitCategory];
             if (originAirbase != null)
                 ctx.ExtraSettings["HotStart"] = true;
@@ -77,6 +116,18 @@ namespace BriefingRoom4DCS.Generator.Mission.Objectives
                 groupLua = "HeloCombatDrop";
             }
 
+            if (ctx.UnitDBs.FirstOrDefault() is DBEntryAircraft escortedAircraft)
+            {
+                double slowestPlayerSpeed = escortedAircraft.CruiseSpeed;
+                foreach (var playerGroup in ctx.Mission.TemplateRecord.PlayerFlightGroups)
+                {
+                    var playerAircraft = briefingRoom.Database.GetEntry<DBEntryJSONUnit>(playerGroup.Aircraft) as DBEntryAircraft;
+                    if (playerAircraft != null && playerAircraft.CruiseSpeed < slowestPlayerSpeed)
+                        slowestPlayerSpeed = playerAircraft.CruiseSpeed;
+                }
+                ctx.ExtraSettings["Speed"] = slowestPlayerSpeed;
+            }
+
             GroupInfo? VIPGroupInfo = UnitGenerator.AddUnitGroup(
                 briefingRoom,
                 ref ctx.Mission,
@@ -90,6 +141,10 @@ namespace BriefingRoom4DCS.Generator.Mission.Objectives
 
             if (!VIPGroupInfo.HasValue)
                 throw new BriefingRoomException(briefingRoom.Database, mission.LangKey, "FailedToGenerateGroupObjective");
+
+            // Capture the clean callsign/group name now, before AssignTargetSuffix() below appends
+            // the "-TGT-<objective>" scripting suffix onto DCSGroup.Name.
+            var escortGroupName = VIPGroupInfo.Value.Name;
 
             VIPGroupInfo.Value.DCSGroups.ForEach(grp =>
             {
@@ -112,8 +167,11 @@ namespace BriefingRoom4DCS.Generator.Mission.Objectives
             ctx.Mission.Waypoints.Add(cargoWaypoint);
             ctx.ObjectiveWaypoints.Add(cargoWaypoint);
 
+            AddEscortAltitudeInfo(ctx, VIPGroupInfo.Value, targetDB.UnitCategory);
             ObjectiveUtils.AssignTargetSuffix(ref VIPGroupInfo, ctx.ObjectiveName, false);
-            ObjectiveCreationHelpers.AddBriefingItems(ctx, VIPGroupInfo.Value, false);
+            AddEscortBriefingTokens(ctx, VIPGroupInfo.Value, targetDB.UnitCategory, escortGroupName);
+            AddEscortKneeboardFlightEntry(ctx, VIPGroupInfo.Value, targetDB.UnitCategory, escortGroupName, originAirbase);
+            ObjectiveCreationHelpers.AddBriefingItems(ctx, VIPGroupInfo.Value, false);            
             ObjectiveCreationHelpers.AddBriefingRemarks(ctx, ObjectiveCreationHelpers.GetPluralIndex(VIPGroupInfo.Value, false));
             ObjectiveCreationHelpers.AddOggFilesAndFeatures(ctx, VIPGroupInfo.Value);
 
@@ -128,6 +186,71 @@ namespace BriefingRoom4DCS.Generator.Mission.Objectives
             objectiveCoordinates = ctx.ObjectiveCoordinates;
 
             return ObjectiveCreationHelpers.FinalizeObjective(ctx, VIPGroupInfo.Value);
+        }
+
+/// <summary>
+        /// Exposes the escorted unit's callsign/group name and cruise altitude to the briefing/kneeboard
+        /// task text via the $ESCORTGROUPNAME$ and $ESCORTALTITUDECLAUSE$ tokens (see
+        /// Database/ObjectiveTasks/Escort.ini). Altitude is left blank for non-aircraft targets
+        /// (ground/ship escorts have no meaningful "altitude").
+        /// </summary>
+        private static void AddEscortBriefingTokens(ObjectiveContext ctx, GroupInfo escortedGroup, UnitCategory unitCategory, string groupName)
+        {
+            ctx.LuaExtraSettings["EscortGroupName"] = groupName;
+
+            string altitudeClause = "";
+            if ((unitCategory == UnitCategory.Plane || unitCategory == UnitCategory.Helicopter) &&
+                escortedGroup.UnitDB is DBEntryAircraft aircraftDB)
+            {
+                int altitudeFt = (int)Math.Round(aircraftDB.CruiseAlt * Toolbox.METERS_TO_FEET / 500.0) * 500;
+                bool isHelicopter = aircraftDB.Families != null && aircraftDB.Families.Length > 0 && aircraftDB.Families[0].GetUnitCategory() == UnitCategory.Helicopter;
+                string altTypeStr = isHelicopter ? "AGL" : "MSL";
+                altitudeClause = $" at approximately {altitudeFt:N0} ft {altTypeStr}";
+            }
+            ctx.LuaExtraSettings["EscortAltitudeClause"] = altitudeClause;
+        }
+
+        /// <summary>
+        /// Adds the escorted flight to the kneeboard "Flights" table and the full-briefing flight-groups
+        /// table (Include/Html/KneeboardFlights.html, Briefing.html) so players can see its callsign,
+        /// aircraft type, and radio frequency alongside their own flights. Only added for airborne
+        /// escorts (Plane/Helicopter) - ground/ship escorts have no equivalent kneeboard table.
+        /// </summary>
+        private static void AddEscortKneeboardFlightEntry(ObjectiveContext ctx, GroupInfo escortedGroup, UnitCategory unitCategory, string groupName, DBEntryAirbase originAirbase)
+        {
+            if (unitCategory != UnitCategory.Plane && unitCategory != UnitCategory.Helicopter)
+                return;
+
+            bool isRampSpawn = originAirbase != null && Constants.AIRBASE_LOCATIONS.Contains(ctx.TargetBehaviorDB.Location);
+            string departure = isRampSpawn ? $"{originAirbase.UIDisplayName.Get(ctx.Mission.LangKey)} (Ramp)" : "Air Spawn";
+
+            if (!isRampSpawn && escortedGroup.UnitDB is DBEntryAircraft aircraftDB)
+            {
+                double speed = ctx.ExtraSettings.ContainsKey("Speed") ? Convert.ToDouble(ctx.ExtraSettings["Speed"]) : aircraftDB.CruiseSpeed;
+                int speedKts = (int)Math.Round(speed * Toolbox.METERS_PER_SECOND_TO_KNOTS);
+                departure += $" ({speedKts:N0} kts)";
+            }
+
+            ctx.Mission.Briefing.AddItem(DCSMissionBriefingItemType.FlightGroup,
+                $"{groupName}(ESCORT)\t" +
+                $"{ctx.UnitCount}× {escortedGroup.UnitDB.UIDisplayName.Get(ctx.Mission.LangKey)}\t" +
+                $"{GeneratorTools.FormatRadioFrequency(escortedGroup.Frequency)}\t" +
+                "-\t" +
+                $"{departure}\t" +
+                $"{ctx.ObjectiveName}");
+        }
+        private static void AddEscortAltitudeInfo(ObjectiveContext ctx, GroupInfo escortedGroup, UnitCategory unitCategory)
+        {
+            string altitudeClause = "";
+            if ((unitCategory == UnitCategory.Plane || unitCategory == UnitCategory.Helicopter) &&
+                escortedGroup.UnitDB is DBEntryAircraft aircraftDB)
+            {
+                int altitudeFt = (int)Math.Round(aircraftDB.CruiseAlt * Toolbox.METERS_TO_FEET / 500.0) * 500;
+                bool isHelicopter = aircraftDB.Families != null && aircraftDB.Families.Length > 0 && aircraftDB.Families[0].GetUnitCategory() == UnitCategory.Helicopter;
+                string altTypeStr = isHelicopter ? "AGL" : "MSL";
+                altitudeClause = $" at approximately {altitudeFt:N0} ft {altTypeStr}";
+            }
+            ctx.LuaExtraSettings["EscortAltitudeClause"] = altitudeClause;
         }
 
         private static void CreateThreats(IBriefingRoom briefingRoom, ref DCSMission mission, Coordinates unitCoordinates, Coordinates objectiveCoordinates, GroupInfo? VIPGroupInfo, UnitCategory unitCategory, bool playerHasPlanes)

--- a/src/BriefingRoom/Generator/MissionGenerator/Objectives/ObjectiveCreationHelpers.cs
+++ b/src/BriefingRoom/Generator/MissionGenerator/Objectives/ObjectiveCreationHelpers.cs
@@ -37,7 +37,13 @@ namespace BriefingRoom4DCS.Generator.Mission.Objectives
             
             mission.AppendValue("ScriptObjectives", objectiveLua);
 
-            foreach (var completionTriggerLua in taskDB.CompletionTriggersLua)
+            var triggers = taskDB.CompletionTriggersLua;
+            if (taskDB.IsEscort() && mission.TemplateRecord.OptionsMission.Contains("StrictEscortDamageThreshold"))
+            {
+                triggers = triggers.Select(x => x == "KeepAlive.lua" ? "KeepUndamaged.lua" : x).ToArray();
+            }
+
+            foreach (var completionTriggerLua in triggers)
             {
                 string triggerLua = Toolbox.ReadAllTextIfFileExists(
                     Path.Combine(BRPaths.INCLUDE_LUA_OBJECTIVETRIGGERS, completionTriggerLua));

--- a/src/BriefingRoom/Generator/MissionGenerator/Objectives/Utils.cs
+++ b/src/BriefingRoom/Generator/MissionGenerator/Objectives/Utils.cs
@@ -174,7 +174,10 @@ namespace BriefingRoom4DCS.Generator.Mission.Objectives
             if (targetBehaviorDB == null) throw new BriefingRoomException(database, langKey, "BehaviorNotFound", targetBehaviorDB.UIDisplayName);
             if (taskDB == null) throw new BriefingRoomException(database, langKey, "TaskNotFound", taskDB.UIDisplayName);
             if (!taskDB.ValidUnitCategories.Contains(targetDB.UnitCategory))
-                throw new BriefingRoomException(database, langKey, "TaskTargetsInvalid", taskDB.UIDisplayName, targetDB.UnitCategory);
+                throw new BriefingRoomException(database, langKey, "TargetCategoryMismatch", targetDB.UIDisplayName, targetDB.UnitCategory, taskDB.UIDisplayName, String.Join(", ", taskDB.ValidUnitCategories.Select(x => x.ToString()).ToList()));
+
+            if (taskDB.ValidTargetIDs.Length > 0 && !taskDB.ValidTargetIDs.Contains(targetDB.ID))
+                throw new BriefingRoomException(database, langKey, "TargetCategoryMismatch", targetDB.UIDisplayName, targetDB.UnitCategory, taskDB.UIDisplayName, String.Join(", ", taskDB.ValidTargetIDs));
         }
     }
 }

--- a/src/BriefingRoom/Generator/MissionGenerator/PlayerFlightGroups.cs
+++ b/src/BriefingRoom/Generator/MissionGenerator/PlayerFlightGroups.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ==========================================================================
 This file is part of Briefing Room for DCS World, a mission
 generator for DCS World, by @akaAgar (https://github.com/akaAgar/briefing-room-for-dcs)
@@ -211,8 +211,7 @@ namespace BriefingRoom4DCS.Generator.Mission
                 extraSettings.AddIfKeyUnused("ParkingID", parkingSpotIDsList);
                 extraSettings.AddIfKeyUnused("UnitCoords", parkingSpotCoordinatesList);
             }
-
-            var task = GetTaskType(mission.TemplateRecord.Objectives, extraSettings, package);
+            var task = GetTaskType(mission, mission.TemplateRecord.Objectives, extraSettings, package, unitDB);
 
             GroupInfo? groupInfo = UnitGenerator.AddUnitGroup(
                 briefingRoom,
@@ -304,18 +303,51 @@ namespace BriefingRoom4DCS.Generator.Mission
             });
         }
 
-        private static DCSTask GetTaskType(List<MissionTemplateObjectiveRecord> objectives, Dictionary<string, object> extraSettings, MissionTemplatePackageRecord package)
+        private static DCSTask GetTaskType(DCSMission mission, List<MissionTemplateObjectiveRecord> objectives, Dictionary<string, object> extraSettings, MissionTemplatePackageRecord package, DBEntryAircraft unitDB)
         {
             var objs = objectives;
             if (package != null)
                 objs = objs.Where((x, i) => package.ObjectiveIndexes.Contains(i)).ToList();
-            var task = objectives.Select(x => new List<DCSTask> { AssignTask(x) }.Concat(x.SubTasks.Select(y => AssignTask(y)).ToList())).SelectMany(x => x).ToList().GroupBy(x => x).MaxBy(g => g.Count()).ToList().First();
+            var task = objs.Select(x => new List<DCSTask> { AssignTask(mission, x, unitDB) }.Concat(x.SubTasks.Select(y => AssignTask(mission, y, unitDB)).ToList())).SelectMany(x => x).ToList().GroupBy(x => x).MaxBy(g => g.Count()).ToList().First();
             extraSettings.AddIfKeyUnused("DCSTask", task);
             return task;
         }
 
-        private static DCSTask AssignTask(MissionTemplateSubTaskRecord objective)
+        private static DCSTask AssignTask(DCSMission mission, MissionTemplateSubTaskRecord objective, DBEntryAircraft unitDB)
         {
+            if (objective.Task.StartsWith("Escort") || objective.Task.StartsWith("Support") || objective.Task.StartsWith("HoldSuperiority"))
+            {
+                string dynamicBehavior = objective.TargetBehavior;
+                string dynamicKey = $"DynamicBehavior_{objective.GetHashCode()}";
+                if (mission.Values.ContainsKey(dynamicKey))
+                    dynamicBehavior = mission.Values[dynamicKey];
+
+                bool isEscortTargetAttacking = objective.Preset == "SupportStrikePackage" ||
+                    objective.Target == "PlaneAttack" ||
+                    objective.Target == "PlaneBomber" ||
+                    objective.Target == "PlaneStrike" ||
+                    objective.Target == "HelicopterAttack" ||
+                    (dynamicBehavior != null && dynamicBehavior.StartsWith("Attack"));
+
+                bool isSeadCapable = unitDB != null && unitDB.Tasks != null && unitDB.Tasks.Contains(DCSTask.SEAD);
+
+                if (isSeadCapable)
+                {
+                    AmountNR samThreat = mission.TemplateRecord.SituationEnemyAirDefense.Get();
+                    AmountNR fighterThreat = mission.TemplateRecord.SituationEnemyAirForce.Get();
+
+                    // If escorted unit is attacking ground, SAMs are a major threat. Provide SEAD if SAMs are Average or higher.
+                    if (isEscortTargetAttacking && samThreat >= AmountNR.Average)
+                        return DCSTask.SEAD;
+
+                    // If escorted unit is not attacking (e.g. Cargo, AWACS, CAP), fighters are usually the primary threat.
+                    // Only take SEAD if SAM threat is actively worse than Fighter threat AND is at least Average.
+                    if (!isEscortTargetAttacking && samThreat >= AmountNR.Average && samThreat > fighterThreat)
+                        return DCSTask.SEAD;
+                }
+
+                return DCSTask.CAP;
+            }
             if (objective.Task.StartsWith("Transport") || objective.Task.StartsWith("LandNear") || objective.Task.StartsWith("Extract"))
                 return DCSTask.Transport;
             if (objective.Task.StartsWith("FlyNear"))

--- a/src/BriefingRoom/Template/ObjectivePresetSuitability.cs
+++ b/src/BriefingRoom/Template/ObjectivePresetSuitability.cs
@@ -92,6 +92,16 @@ namespace BriefingRoom4DCS.Template
             if (profile.IsRotorOnly && PresetTargetsPlanes(database, preset))
                 return ObjectivePresetUnsuitabilityReason.PlaneTargetsRotorOnly;
 
+            var task = database.GetEntry<DBEntryObjectiveTask>(preset.Task);
+            if (task != null)
+            {
+                if (profile.HasFixedWingAircraft && !profile.HasRotorAircraft && !task.ValidPlayerUnitCategories.Contains(UnitCategory.Plane))
+                    return ObjectivePresetUnsuitabilityReason.AircraftTypeMismatch;
+                
+                if (profile.IsRotorOnly && !task.ValidPlayerUnitCategories.Contains(UnitCategory.Helicopter))
+                    return ObjectivePresetUnsuitabilityReason.AircraftTypeMismatch;
+            }
+
             return ObjectivePresetUnsuitabilityReason.None;
         }
 

--- a/src/Tests/ObjectiveBriefingTests.cs
+++ b/src/Tests/ObjectiveBriefingTests.cs
@@ -1,0 +1,107 @@
+using System.IO;
+using BriefingRoom4DCS.Mission;
+
+namespace BriefingRoom4DCS.Tests;
+
+[Collection("Database collection")]
+public class ObjectiveBriefingTests
+{
+    private readonly DatabaseFixture fixture;
+
+    public ObjectiveBriefingTests(DatabaseFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    [Fact]
+    public void EscortAndDynamicSpawnObjectivesAddSpawnDetailsToBriefing()
+    {
+        var templatePath = Path.Combine(Path.GetTempPath(), $"escort-briefing-{Guid.NewGuid():N}.brt");
+        try
+        {
+            File.WriteAllText(templatePath, """
+                [context]
+                coalitionblue=USA
+                coalitionred=Russia
+                decade=Decade2000
+                playercoalition=Blue
+                theater=Caucasus
+
+                [flightplan]
+                objectivedistancemax=160
+                objectivedistancemin=40
+                objectiveseparationmax=100
+                objectiveseparationmin=10
+                borderlimit=100
+
+                [missionfeatures]
+                missionfeatures=FriendlyAWACS,FriendlyTankerBasket,FriendlyTankerBoom
+
+                [mods]
+
+                [options]
+                fogofwar=All
+                mission=ImperialUnitsForBriefing,MarkWaypoints,DisableKneeboardImages
+                realism=DisableDCSRadioAssists,NoBDA
+
+                [playerflightgroups]
+                playerflightgroup000.aircrafttype=Su-25T
+                playerflightgroup000.aiwingmen=False
+                playerflightgroup000.hostile=False
+                playerflightgroup000.count=2
+                playerflightgroup000.payload=default
+                playerflightgroup000.country=CombinedJointTaskForcesRed
+                playerflightgroup000.startlocation=Runway
+                playerflightgroup000.livery=default
+                playerflightgroup000.overrideradioband=AM
+                playerflightgroup000.overridecallsignnumber=1
+
+                [situation]
+                enemyskill=Random
+                enemyairdefense=Random
+                enemyairforce=Random
+                friendlyskill=Random
+                friendlyairdefense=Random
+                friendlyairforce=Random
+
+                [combinedarms]
+                commanderblue=0
+                commanderred=0
+                jtacblue=0
+                jtacred=0
+
+                [briefing]
+
+                [environment]
+                season=Random
+                timeofday=RandomDaytime
+                wind=Random
+
+                [objectives]
+                objective000.preset=EscortPlane
+                objective000.coordinatehint=0,0
+                """);
+
+            var briefingRoom = new BriefingRoom(fixture.Db);
+            var mission = briefingRoom.GenerateMission(templatePath);
+
+            var tasks = mission.Briefing.GetItems(DCSMissionBriefingItemType.Task)
+                .Select(x => x.ToLowerInvariant())
+                .ToList();
+
+            var remarks = mission.Briefing.GetItems(DCSMissionBriefingItemType.Remark)
+                .Select(x => x.ToLowerInvariant())
+                .ToList();
+
+            Assert.Contains(tasks, x => x.Contains("approximately") && x.Contains("ft"));
+            Assert.NotEmpty(remarks);
+        }
+        finally
+        {
+            if (File.Exists(templatePath))
+                File.Delete(templatePath);
+        }
+    }
+
+
+}


### PR DESCRIPTION
* Altered tasks in favor of unified Escort framework (AI Written)

* Added: Dynamic DCSTask resolution for Escort objectives based on escorted unit type (AI Written)
* Added: Supported units to kneeboards and map markers (AI Written)
* Updated: Escort and Support missions to set specific DCS tasks (GroundAttack, Reconnaissance, Transport, AWACS) for escorted AI flights (AI Written)
* Updated: Escort objective kneeboard generation and UI to reflect dynamically capped cruise speed and AGL altitude (AI Written)
* Updated: Cap Escort target aircraft speed to match the slowest escorting player aircraft (AI Written)
* Updated: Kneeboard departure point to display origin airbase ramp or air spawn for escort flights (AI Written)
* Fixed: Escort objective assigning Plane/Helicopter targets by removing them from ValidUnitCategories (AI Written)
* Fixed: F10 menu option not spawning units for support missions (AI Written)